### PR TITLE
.NET 7 support

### DIFF
--- a/CryptSharp.Demo/CryptSharp.Core.Demo.csproj
+++ b/CryptSharp.Demo/CryptSharp.Core.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 

--- a/CryptSharp/CryptSharp.Core.csproj
+++ b/CryptSharp/CryptSharp.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/CryptSharp/Utility/SCrypt.cs
+++ b/CryptSharp/Utility/SCrypt.cs
@@ -180,7 +180,7 @@ namespace CryptSharp.Core.Utility
 
             int threadCount = Math.Max(1, Math.Min(Environment.ProcessorCount, Math.Min(maxThreads, parallel)));
             Thread[] threads = new Thread[threadCount - 1];
-            for (int i = 0; i < threads.Length; i++) { (threads[i] = new Thread(workerThread, 8192)).Start(); }
+            for (int i = 0; i < threads.Length; i++) { (threads[i] = new Thread(workerThread)).Start(); }
             workerThread();
             for (int i = 0; i < threads.Length; i++) { threads[i].Join(); }
         }


### PR DESCRIPTION
- Remove max stack size value for new threads and use the system default instead.
- Add net7.0 to target frameworks list.

See [further discussions here](https://github.com/dotnet/runtime/issues/78444).